### PR TITLE
Breaking change fix - writeStatic is deprecated

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,6 @@ export default function ({
 			builder.rimraf(assets)
 			builder.rimraf(pages)
 
-			builder.writeStatic(assets)
 			builder.writeClient(assets)
 			builder.writePrerendered(pages, { fallback })
 


### PR DESCRIPTION
Have writeClient write both the client and static files and remove writeStatic. This is a breaking change for adapter authors.

[breaking] remove writeStatic to align with Vite #5618
https://github.com/sveltejs/kit/pull/5618